### PR TITLE
Fix bold text conversion issue in md_to_jira.py

### DIFF
--- a/md_to_jira.py
+++ b/md_to_jira.py
@@ -28,11 +28,17 @@ def convert_line(line):
     line = re.sub(r'^#{2}\s*(.+)', r'h2. \1', line)
     line = re.sub(r'^#\s*(.+)', r'h1. \1', line)
 
-    # Convert bold and italic
-    line = re.sub(r'\*\*(.+?)\*\*', r'*\1*', line)
-    line = re.sub(r'__(.+?)__', r'*\1*', line)
+    # Convert bold
+    bold_placeholder = "bold78c10ae05c702eb1cbold"
+    line = re.sub(r'\*\*(.+?)\*\*', r'{placeholder}\1{placeholder}'.format(placeholder=bold_placeholder), line)
+    line = re.sub(r'__(.+?)__', r'{placeholder}\1{placeholder}'.format(placeholder=bold_placeholder), line)
+
+    # Convert italic
     line = re.sub(r'\*(.+?)\*', r'_\1_', line)
     line = re.sub(r'_(.+?)_', r'_\1_', line)
+
+    # Convert placeholder back to bold
+    line = re.sub(r'{placeholder}(.+?){placeholder}'.format(placeholder=bold_placeholder), r'*\1*', line)
 
     # Convert inline code
     line = re.sub(r'`([^`]+)`', r'{{\1}}', line)

--- a/md_to_jira.py
+++ b/md_to_jira.py
@@ -17,6 +17,7 @@
 
 import sys
 import re
+import uuid
 
 
 def convert_line(line):
@@ -29,7 +30,7 @@ def convert_line(line):
     line = re.sub(r'^#\s*(.+)', r'h1. \1', line)
 
     # Convert bold
-    bold_placeholder = "bold78c10ae05c702eb1cbold"
+    bold_placeholder = f"BOLD_{uuid.uuid4()}_BOLD"
     line = re.sub(r'\*\*(.+?)\*\*', r'{placeholder}\1{placeholder}'.format(placeholder=bold_placeholder), line)
     line = re.sub(r'__(.+?)__', r'{placeholder}\1{placeholder}'.format(placeholder=bold_placeholder), line)
 

--- a/test_md_to_jira.py
+++ b/test_md_to_jira.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import re
+from textwrap import dedent
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+from md_to_jira import convert_line, convert_multiline_elements, markdown_to_jira
+
+
+class TestMdToJira(unittest.TestCase):
+    def test_convert_line(self):
+        self.assertEqual(convert_line('# Header'), 'h1. Header')
+        self.assertEqual(convert_line('## Header'), 'h2. Header')
+        self.assertEqual(convert_line('### Header'), 'h3. Header')
+        self.assertEqual(convert_line('#### Header'), 'h4. Header')
+        self.assertEqual(convert_line('##### Header'), 'h5. Header')
+        self.assertEqual(convert_line('###### Header'), 'h6. Header')
+        self.assertEqual(convert_line('**bold**'), '*bold*')
+        self.assertEqual(convert_line('__bold__'), '*bold*')
+        self.assertEqual(convert_line('*italic*'), '_italic_')
+        self.assertEqual(convert_line('_italic_'), '_italic_')
+        self.assertEqual(convert_line('`code`'), '{{code}}')
+        self.assertEqual(convert_line('~~strikethrough~~'), '-strikethrough-')
+        self.assertEqual(convert_line('[link](http://example.com)'), '[link|http://example.com]')
+        self.assertEqual(convert_line('* item'), '- item')
+        self.assertEqual(convert_line('- [x] task'), '[x] task')
+        self.assertEqual(convert_line('- [ ] task'), '[ ] task')
+        self.assertEqual(convert_line('- [X] task'), '[X] task')
+
+    def test_convert_multiline_elements(self):
+        self.assertEqual(convert_multiline_elements('```python\nprint("Hello World!")\n```'), '{code:python}\nprint("Hello World!")\n{code}')
+
+    def test_markdown_to_jira(self):
+        test_md_content = dedent('''\
+            # Test Markdown Syntax Formatting
+
+            ## Header
+
+            * item
+
+            - [x] task
+
+            ```python
+            print('Hello, World!')
+            ```
+            ''')
+
+        expected_output = "h1. Test Markdown Syntax Formatting\n\nh2. Header\n\n- item\n\n[x] task\n\n{code:python}\nprint('Hello, World!')\n{code}\n"
+
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            with patch('builtins.open', return_value=StringIO(test_md_content)):
+                markdown_to_jira("test.md")
+                self.assertEqual(fake_out.getvalue(), expected_output)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix the conversion of bold text in markdown to Jira format.

* Replace the bold conversion logic in `md_to_jira.py` with a placeholder approach to avoid interference with italic conversion.
* Add a step to convert the placeholder back to bold after italic conversion in `md_to_jira.py`.
* Add unit tests in `test_md_to_jira.py` to verify that `**bold**` turns into `*bold*` and `*italic*` turns into `_italic_`.

